### PR TITLE
SP5WWP/inc/m17.h, SP5WWP/m17-Xcoder/*.h: adding extern C (required to link with cpp code)

### DIFF
--- a/SP5WWP/inc/m17.h
+++ b/SP5WWP/inc/m17.h
@@ -1,6 +1,10 @@
 #ifndef M17_CONSTS
 #define M17_CONSTS
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define FLT_LEN             81  //baseband filter length (number of taps)
 #define SW_LEN              80  //syncword detector length
 #define XC_LEN              90  //cross-correlator lookback length in samples
@@ -98,5 +102,9 @@ const uint16_t intrl_seq[368]=
 	32, 169, 122, 259, 212, 349, 302, 71, 24, 161, 114, 251, 204, 341, 294, 63,
 	16, 153, 106, 243, 196, 333, 286, 55, 8, 145, 98, 235, 188, 325, 278, 47
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/SP5WWP/m17-coder/crc.h
+++ b/SP5WWP/m17-coder/crc.h
@@ -1,6 +1,14 @@
 #ifndef CRC_H
 #define CRC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 uint16_t CRC_M17(const uint8_t *in, const uint16_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/SP5WWP/m17-decoder/crc.h
+++ b/SP5WWP/m17-decoder/crc.h
@@ -1,6 +1,14 @@
 #ifndef CRC_H
 #define CRC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 uint16_t CRC_M17(const uint8_t *in, const uint16_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/SP5WWP/m17-decoder/golay.h
+++ b/SP5WWP/m17-decoder/golay.h
@@ -1,6 +1,10 @@
 #ifndef GOLAY_H
 #define GOLAY_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void IntToSoft(uint16_t* out, const uint16_t in, uint8_t len);
 uint16_t SoftToInt(const uint16_t* in, uint8_t len);
 uint16_t Div16(uint16_t a, uint16_t b);
@@ -11,5 +15,9 @@ uint32_t spopcount(const uint16_t* in, uint8_t siz);
 void calcChecksumS(uint16_t* out, const uint16_t* value);
 uint32_t SdetectErrors(const uint16_t* codeword);
 uint16_t golay24_sdecode(const uint16_t* codeword);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/SP5WWP/m17-decoder/viterbi.h
+++ b/SP5WWP/m17-decoder/viterbi.h
@@ -1,11 +1,19 @@
 #ifndef VITERBI_H
 #define VITERBI_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 uint32_t decode(uint8_t* out, const uint16_t* in, uint16_t len);
 uint32_t decodePunctured(uint8_t* out, const uint16_t* in, const uint8_t* punct, const uint16_t in_len, const uint16_t p_len);
 void decodeBit(uint16_t s0, uint16_t s1, size_t pos);
 uint32_t chainback(uint8_t* out, size_t pos, uint16_t len);
 uint16_t q_AbsDiff(const uint16_t v1, const uint16_t v2);
 void reset(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Importing m17 python module fails with:

```
>>> import gnuradio.m17  
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib64/python3.10/site-packages/gnuradio/m17/__init__.py",
line 18, in <module> from .m17_python import *
ImportError: /usr/local/lib64/libgnuradio-m17.so.1.0.0: undefined symbol: _Z7CRC_M17PKht
```

This isn't python related but it's due to a different naming between C and CPP.

By adding, before functions declaration in headers:

#ifdef __cplusplus
extern "C" {
#endif

And, these lines, at the header end

#ifdef __cplusplus
}
#endif

The problem is fixed and the import succeeded:

```
>>> import gnuradio.m17
>>> m
map(         max(         memoryview(  min(         
>>> from gnuradio import m17
>>> m17.<TAB>
m17.m17_coder(    m17.m17_decoder(  m17.m17_python    m17.os 
```